### PR TITLE
Configuration variable optimization and fix

### DIFF
--- a/components/sen5x/automation.h
+++ b/components/sen5x/automation.h
@@ -7,7 +7,6 @@
 namespace esphome {
 namespace sen5x {
 
-
 template<typename... Ts> class SetAmbientPressurehPa : public Action<Ts...>, public Parented<SEN5XComponent> {
  public:
   void play(Ts... x) override {
@@ -20,7 +19,8 @@ template<typename... Ts> class SetAmbientPressurehPa : public Action<Ts...>, pub
   TEMPLATABLE_VALUE(uint16_t, value)
 };
 
-template<typename... Ts> class PerformForcedCo2CalibrationAction : public Action<Ts...>, public Parented<SEN5XComponent> {
+template<typename... Ts>
+class PerformForcedCo2CalibrationAction : public Action<Ts...>, public Parented<SEN5XComponent> {
  public:
   void play(Ts... x) override {
     if (this->value_.has_value()) {

--- a/components/sen5x/sen5x.cpp
+++ b/components/sen5x/sen5x.cpp
@@ -332,8 +332,8 @@ void SEN5XComponent::internal_setup_(uint8_t state) {
           this->mark_failed();
           return;
         }
-        if (!this->write_command(SEN6X_CMD_CO2_SENSOR_AUTO_SELF_CAL, this->co2_auto_calibrate_.value() ? 0x01 : 0x00)) {
-          ESP_LOGE(TAG, "Failed to set CO₂ Sensor Automatic Self Calibration");
+        if (!this->write_command(SEN6X_CMD_SENSOR_ALTITUDE, this->co2_altitude_compensation_.value())) {
+          ESP_LOGE(TAG, "Failed to set CO₂ Sensor Altitude Compensation");
           this->error_code_ = COMMUNICATION_FAILED;
           this->mark_failed();
           return;
@@ -477,7 +477,7 @@ void SEN5XComponent::dump_config() {
   LOG_SENSOR("  ", "NOx", this->nox_sensor_);
   LOG_SENSOR("  ", "CO₂", this->co2_sensor_);
   if (this->co2_sensor_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "    Automatic self calibration: %s", co2_auto_calibrate_ ? "On" : "Off");
+    ESP_LOGCONFIG(TAG, "    Automatic self calibration: %s", this->co2_auto_calibrate_.value() ? "On" : "Off");
     if (this->co2_ambient_pressure_source_ != nullptr) {
       ESP_LOGCONFIG(TAG, "    Dynamic ambient pressure compensation using sensor '%s'",
                     this->co2_ambient_pressure_source_->get_name().c_str());

--- a/components/sen5x/sensor.py
+++ b/components/sen5x/sensor.py
@@ -4,7 +4,12 @@ import esphome.codegen as cg
 from esphome.components import i2c, sensirion_common, sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ALTITUDE_COMPENSATION,
+    CONF_AMBIENT_PRESSURE_COMPENSATION,
+    CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE,
+    CONF_AUTOMATIC_SELF_CALIBRATION,
     CONF_CO2,
+    CONF_GAIN_FACTOR,
     CONF_HUMIDITY,
     CONF_ID,
     CONF_MODEL,
@@ -50,13 +55,8 @@ RhtAccelerationMode = sen5x_ns.enum("RhtAccelerationMode")
 
 
 CONF_ACCELERATION_MODE = "acceleration_mode"
-CONF_ALTITUDE_COMPENSATION = "altitude_compensation"
-CONF_AMBIENT_PRESSURE_COMPENSATION = "ambient_pressure_compensation"
-CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE = "ambient_pressure_compensation_source"
 CONF_ALGORITHM_TUNING = "algorithm_tuning"
 CONF_AUTO_CLEANING_INTERVAL = "auto_cleaning_interval"
-CONF_AUTO_SELF_CALIBRATION = "auto_self_calibration"
-CONF_GAIN_FACTOR = "gain_factor"
 CONF_GATING_MAX_DURATION_MINUTES = "gating_max_duration_minutes"
 CONF_HCHO = "hcho"
 CONF_INDEX_OFFSET = "index_offset"
@@ -118,7 +118,7 @@ GAS_SENSOR = cv.Schema(
 
 CO2_SENSOR = cv.Schema(
     {
-        cv.Optional(CONF_AUTO_SELF_CALIBRATION, default=True): cv.boolean,
+        cv.Optional(CONF_AUTOMATIC_SELF_CALIBRATION, default=True): cv.boolean,
         cv.Optional(CONF_ALTITUDE_COMPENSATION, default="0m"): cv.All(
             cv.float_with_unit("altitude", "(m|m a.s.l.|MAMSL|MASL)"),
             cv.int_range(min=0, max=0xFFFF, max_included=False),
@@ -247,7 +247,7 @@ SETTING_MAP = {
 }
 
 CO2_SETTING_MAP = {
-    CONF_AUTO_SELF_CALIBRATION: "set_co2_auto_calibrate",
+    CONF_AUTOMATIC_SELF_CALIBRATION: "set_co2_auto_calibrate",
     CONF_ALTITUDE_COMPENSATION: "set_co2_altitude_compensation",
     CONF_AMBIENT_PRESSURE_COMPENSATION: "set_co2_ambient_pressure_compensation",
 }

--- a/components/sen5x/sensor.py
+++ b/components/sen5x/sensor.py
@@ -4,7 +4,7 @@ import esphome.codegen as cg
 from esphome.components import i2c, sensirion_common, sensor
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ALTITUDE_COMPENSATION,
+    # CONF_ALTITUDE_COMPENSATION,
     CONF_AMBIENT_PRESSURE_COMPENSATION,
     CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE,
     CONF_AUTOMATIC_SELF_CALIBRATION,
@@ -56,6 +56,7 @@ RhtAccelerationMode = sen5x_ns.enum("RhtAccelerationMode")
 
 CONF_ACCELERATION_MODE = "acceleration_mode"
 CONF_ALGORITHM_TUNING = "algorithm_tuning"
+CONF_ALTITUDE_COMPENSATION = "altitude_compensation"
 CONF_AUTO_CLEANING_INTERVAL = "auto_cleaning_interval"
 CONF_GATING_MAX_DURATION_MINUTES = "gating_max_duration_minutes"
 CONF_HCHO = "hcho"


### PR DESCRIPTION
Fix auto calibration reporting error in  dump_config()
Move too consts.py configuration variables names for several variables